### PR TITLE
feat: extended auth flows + RBAC system

### DIFF
--- a/alembic/versions/202604260850_initial_auth_schema.py
+++ b/alembic/versions/202604260850_initial_auth_schema.py
@@ -25,6 +25,7 @@ role_table = sa.table(
     sa.column("id", postgresql.UUID(as_uuid=True)),
     sa.column("name", sa.String(length=50)),
     sa.column("description", sa.String(length=255)),
+    sa.column("is_tenant_role", sa.Boolean()),
     sa.column("created_at", sa.DateTime(timezone=True)),
 )
 
@@ -49,6 +50,7 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
         sa.Column("name", sa.String(length=50), nullable=False),
         sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("is_tenant_role", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
     )
     op.create_index(op.f("ix_roles_name"), "roles", ["name"], unique=True)
@@ -116,30 +118,35 @@ def upgrade() -> None:
                 "id": uuid.UUID("11111111-1111-1111-1111-111111111111"),
                 "name": "super_admin",
                 "description": "Super administrator",
+                "is_tenant_role": False,
                 "created_at": datetime.now(UTC),
             },
             {
                 "id": uuid.UUID("22222222-2222-2222-2222-222222222222"),
                 "name": "admin",
                 "description": "Administrator",
+                "is_tenant_role": False,
                 "created_at": datetime.now(UTC),
             },
             {
                 "id": uuid.UUID("33333333-3333-3333-3333-333333333333"),
                 "name": "user",
                 "description": "Standard user",
+                "is_tenant_role": False,
                 "created_at": datetime.now(UTC),
             },
             {
                 "id": uuid.UUID("44444444-4444-4444-4444-444444444444"),
                 "name": "tenant_admin",
                 "description": "Tenant administrator",
+                "is_tenant_role": True,
                 "created_at": datetime.now(UTC),
             },
             {
                 "id": uuid.UUID("55555555-5555-5555-5555-555555555555"),
                 "name": "tenant_member",
                 "description": "Tenant member",
+                "is_tenant_role": True,
                 "created_at": datetime.now(UTC),
             },
         ],

--- a/alembic/versions/202604260900_add_tokens.py
+++ b/alembic/versions/202604260900_add_tokens.py
@@ -1,0 +1,42 @@
+"""add password reset and email verification tokens
+
+Revision ID: 202604260900
+Revises: 202604260850
+Create Date: 2026-04-26 09:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202604260900"
+down_revision: str | None = "202604260850"
+branch_labels: str | Sequence[str] = ()
+depends_on: str | Sequence[str] = ()
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+    op.create_table(
+        "email_verification_tokens",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("email_verification_tokens")
+    op.drop_table("password_reset_tokens")

--- a/alembic/versions/202604260900_add_tokens.py
+++ b/alembic/versions/202604260900_add_tokens.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
         sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
     )
+    op.create_index(op.f("ix_password_reset_tokens_token_hash"), "password_reset_tokens", ["token_hash"], unique=False)
     op.create_table(
         "email_verification_tokens",
         sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
@@ -35,8 +36,11 @@ def upgrade() -> None:
         sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
     )
+    op.create_index(op.f("ix_email_verification_tokens_token_hash"), "email_verification_tokens", ["token_hash"], unique=False)
 
 
 def downgrade() -> None:
+    op.drop_index(op.f("ix_email_verification_tokens_token_hash"), table_name="email_verification_tokens")
     op.drop_table("email_verification_tokens")
+    op.drop_index(op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens")
     op.drop_table("password_reset_tokens")

--- a/alembic/versions/202604260950_add_rbac_tables.py
+++ b/alembic/versions/202604260950_add_rbac_tables.py
@@ -55,11 +55,29 @@ def upgrade() -> None:
 
     op.create_table(
         "user_roles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False, server_default=sa.text("gen_random_uuid()")),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("role_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("user_id", "role_id"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index(op.f("ix_user_roles_tenant_id"), "user_roles", ["tenant_id"], unique=False)
+    op.create_index(
+        "uq_user_roles_global_scope",
+        "user_roles",
+        ["user_id", "role_id"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NULL"),
+    )
+    op.create_index(
+        "uq_user_roles_tenant_scope",
+        "user_roles",
+        ["user_id", "role_id", "tenant_id"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NOT NULL"),
     )
 
     op.bulk_insert(
@@ -68,17 +86,29 @@ def upgrade() -> None:
             {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000001"), "name": "users.read", "description": "View users", "created_at": datetime.utcnow()},
             {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000002"), "name": "users.write", "description": "Create and update users", "created_at": datetime.utcnow()},
             {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000003"), "name": "users.delete", "description": "Delete users", "created_at": datetime.utcnow()},
-            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000004"), "name": "roles.manage", "description": "Manage roles and permissions", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000004"), "name": "roles.manage", "description": "Manage role assignments", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000005"), "name": "permissions.manage", "description": "Manage permission definitions", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000006"), "name": "tenant:create", "description": "Create tenants", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000007"), "name": "tenant:manage", "description": "Manage tenant settings", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000008"), "name": "tenant:invite", "description": "Invite tenant members", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000009"), "name": "tenant:members:read", "description": "View tenant members", "created_at": datetime.utcnow()},
         ],
     )
 
     super_admin = uuid.UUID("11111111-1111-1111-1111-111111111111")
     admin = uuid.UUID("22222222-2222-2222-2222-222222222222")
     user_role = uuid.UUID("33333333-3333-3333-3333-333333333333")
+    tenant_admin = uuid.UUID("44444444-4444-4444-4444-444444444444")
+    tenant_member = uuid.UUID("55555555-5555-5555-5555-555555555555")
     p_read = uuid.UUID("aaaa0001-0001-0001-0001-000000000001")
     p_write = uuid.UUID("aaaa0001-0001-0001-0001-000000000002")
     p_delete = uuid.UUID("aaaa0001-0001-0001-0001-000000000003")
     p_roles = uuid.UUID("aaaa0001-0001-0001-0001-000000000004")
+    p_permissions = uuid.UUID("aaaa0001-0001-0001-0001-000000000005")
+    p_tenant_create = uuid.UUID("aaaa0001-0001-0001-0001-000000000006")
+    p_tenant_manage = uuid.UUID("aaaa0001-0001-0001-0001-000000000007")
+    p_tenant_invite = uuid.UUID("aaaa0001-0001-0001-0001-000000000008")
+    p_tenant_members_read = uuid.UUID("aaaa0001-0001-0001-0001-000000000009")
 
     op.bulk_insert(
         role_permission_table,
@@ -87,14 +117,33 @@ def upgrade() -> None:
             {"role_id": super_admin, "permission_id": p_write},
             {"role_id": super_admin, "permission_id": p_delete},
             {"role_id": super_admin, "permission_id": p_roles},
+            {"role_id": super_admin, "permission_id": p_permissions},
+            {"role_id": super_admin, "permission_id": p_tenant_create},
+            {"role_id": super_admin, "permission_id": p_tenant_manage},
+            {"role_id": super_admin, "permission_id": p_tenant_invite},
+            {"role_id": super_admin, "permission_id": p_tenant_members_read},
             {"role_id": admin, "permission_id": p_read},
             {"role_id": admin, "permission_id": p_write},
-            {"role_id": user_role, "permission_id": p_read},
+            {"role_id": admin, "permission_id": p_roles},
+            {"role_id": admin, "permission_id": p_permissions},
+            {"role_id": admin, "permission_id": p_tenant_create},
+            {"role_id": admin, "permission_id": p_tenant_manage},
+            {"role_id": admin, "permission_id": p_tenant_members_read},
+            {"role_id": tenant_admin, "permission_id": p_read},
+            {"role_id": tenant_admin, "permission_id": p_write},
+            {"role_id": tenant_admin, "permission_id": p_roles},
+            {"role_id": tenant_admin, "permission_id": p_tenant_manage},
+            {"role_id": tenant_admin, "permission_id": p_tenant_invite},
+            {"role_id": tenant_admin, "permission_id": p_tenant_members_read},
+            {"role_id": tenant_member, "permission_id": p_tenant_members_read},
         ],
     )
 
 
 def downgrade() -> None:
+    op.drop_index("uq_user_roles_tenant_scope", table_name="user_roles")
+    op.drop_index("uq_user_roles_global_scope", table_name="user_roles")
+    op.drop_index(op.f("ix_user_roles_tenant_id"), table_name="user_roles")
     op.drop_table("user_roles")
     op.drop_table("role_permissions")
     op.drop_index(op.f("ix_permissions_name"), table_name="permissions")

--- a/alembic/versions/202604260950_add_rbac_tables.py
+++ b/alembic/versions/202604260950_add_rbac_tables.py
@@ -1,0 +1,101 @@
+"""add rbac tables
+
+Revision ID: 202604260950
+Revises: 202604260900
+Create Date: 2026-04-26 09:50:00.000000
+"""
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "202604260950"
+down_revision: str | None = "202604260900"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+permission_table = sa.table(
+    "permissions",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("name", sa.String(length=100)),
+    sa.column("description", sa.String(length=255)),
+    sa.column("created_at", sa.DateTime(timezone=True)),
+)
+
+role_permission_table = sa.table(
+    "role_permissions",
+    sa.column("role_id", postgresql.UUID(as_uuid=True)),
+    sa.column("permission_id", postgresql.UUID(as_uuid=True)),
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "permissions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index(op.f("ix_permissions_name"), "permissions", ["name"], unique=True)
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("role_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("permission_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["permission_id"], ["permissions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("role_id", "permission_id"),
+    )
+
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("role_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+
+    op.bulk_insert(
+        permission_table,
+        [
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000001"), "name": "users.read", "description": "View users", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000002"), "name": "users.write", "description": "Create and update users", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000003"), "name": "users.delete", "description": "Delete users", "created_at": datetime.utcnow()},
+            {"id": uuid.UUID("aaaa0001-0001-0001-0001-000000000004"), "name": "roles.manage", "description": "Manage roles and permissions", "created_at": datetime.utcnow()},
+        ],
+    )
+
+    super_admin = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    admin = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    user_role = uuid.UUID("33333333-3333-3333-3333-333333333333")
+    p_read = uuid.UUID("aaaa0001-0001-0001-0001-000000000001")
+    p_write = uuid.UUID("aaaa0001-0001-0001-0001-000000000002")
+    p_delete = uuid.UUID("aaaa0001-0001-0001-0001-000000000003")
+    p_roles = uuid.UUID("aaaa0001-0001-0001-0001-000000000004")
+
+    op.bulk_insert(
+        role_permission_table,
+        [
+            {"role_id": super_admin, "permission_id": p_read},
+            {"role_id": super_admin, "permission_id": p_write},
+            {"role_id": super_admin, "permission_id": p_delete},
+            {"role_id": super_admin, "permission_id": p_roles},
+            {"role_id": admin, "permission_id": p_read},
+            {"role_id": admin, "permission_id": p_write},
+            {"role_id": user_role, "permission_id": p_read},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_roles")
+    op.drop_table("role_permissions")
+    op.drop_index(op.f("ix_permissions_name"), table_name="permissions")
+    op.drop_table("permissions")

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import structlog
 from fastapi import FastAPI
 
 from app.middleware.tenant import tenant_context_middleware
+from app.routers.admin import router as admin_router
 from app.routers.auth import router as auth_router
 from app.routers.health import router as health_router
 from app.utils.errors import register_exception_handlers
@@ -27,3 +28,4 @@ register_exception_handlers(app)
 app.middleware("http")(tenant_context_middleware)
 app.include_router(health_router)
 app.include_router(auth_router)
+app.include_router(admin_router)

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,6 +1,9 @@
-from fastapi import Depends
+# pyright: reportCallInDefaultInitializer=false
+from uuid import UUID
+
+from fastapi import Depends, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db_session
@@ -28,18 +31,32 @@ async def get_current_user(
     return user
 
 
-def require_permission(permission_name: str):
+async def get_user_permission_names(session: AsyncSession, user_id: UUID, tenant_id: UUID | None = None) -> set[str]:
+    query = (
+        select(Permission.name)
+        .distinct()
+        .join(RolePermission, RolePermission.permission_id == Permission.id)
+        .join(UserRole, UserRole.role_id == RolePermission.role_id)
+        .where(UserRole.user_id == user_id)
+    )
+    if tenant_id is None:
+        query = query.where(UserRole.tenant_id.is_(None))
+    else:
+        query = query.where(or_(UserRole.tenant_id.is_(None), UserRole.tenant_id == tenant_id))
+    permissions = await session.scalars(query)
+    return set(permissions)
+
+
+def require_permission(permission_name: str, *, global_only: bool = False):
     async def check_permission(
+        request: Request,
         current_user: User = Depends(get_current_user),
         session: AsyncSession = Depends(get_db_session),
     ) -> User:
-        result = await session.scalar(
-            select(Permission.name)
-            .join(RolePermission, RolePermission.permission_id == Permission.id)
-            .join(UserRole, UserRole.role_id == RolePermission.role_id)
-            .where(UserRole.user_id == current_user.id, Permission.name == permission_name)
-        )
-        if result is None:
+        tenant_id = None if global_only else getattr(request.state, "tenant_id", None)
+        permissions = await get_user_permission_names(session, current_user.id, tenant_id=tenant_id)
+        if permission_name not in permissions:
             raise AppError(403, "FORBIDDEN", f"Permission '{permission_name}' is required.")
         return current_user
+
     return check_permission

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -4,6 +4,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db_session
+from app.models.permission import Permission
+from app.models.rbac import RolePermission, UserRole
 from app.models.user import User
 from app.services.token_service import TokenService
 from app.utils.errors import AppError
@@ -24,3 +26,20 @@ async def get_current_user(
     if user is None:
         raise AppError(401, "USER_NOT_FOUND", "Authenticated user was not found.")
     return user
+
+
+def require_permission(permission_name: str):
+    async def check_permission(
+        current_user: User = Depends(get_current_user),
+        session: AsyncSession = Depends(get_db_session),
+    ) -> User:
+        result = await session.scalar(
+            select(Permission.name)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .join(UserRole, UserRole.role_id == RolePermission.role_id)
+            .where(UserRole.user_id == current_user.id, Permission.name == permission_name)
+        )
+        if result is None:
+            raise AppError(403, "FORBIDDEN", f"Permission '{permission_name}' is required.")
+        return current_user
+    return check_permission

--- a/app/middleware/tenant.py
+++ b/app/middleware/tenant.py
@@ -1,6 +1,7 @@
+# pyright: reportUnknownVariableType=false
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Awaitable, Callable
 from uuid import UUID
 
 from fastapi import Request
@@ -23,7 +24,7 @@ def _parse_tenant_id(value: str | None) -> UUID | None:
         raise AppError(400, "INVALID_TENANT_ID", "Tenant ID is invalid.") from exc
 
 
-async def tenant_context_middleware(request: Request, call_next: Callable[[Request], Response]) -> Response:
+async def tenant_context_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     request.state.tenant = None
     request.state.tenant_id = None
     request.state.tenant_member = None
@@ -51,6 +52,8 @@ async def tenant_context_middleware(request: Request, call_next: Callable[[Reque
         return await call_next(request)
 
     if user_id is None:
+        if request.url.path == "/api/v1/auth/login":
+            return await call_next(request)
         return build_error_response(401, "AUTHENTICATION_REQUIRED", "Authentication credentials were not provided.")
 
     async with AsyncSessionLocal() as session:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,5 @@
+from app.models.email_verification_token import EmailVerificationToken
+from app.models.password_reset_token import PasswordResetToken
 from app.models.permission import Permission
 from app.models.rbac import RolePermission, UserRole
 from app.models.refresh_token import RefreshToken
@@ -7,4 +9,16 @@ from app.models.tenant_invitation import TenantInvitation
 from app.models.tenant_member import TenantMember
 from app.models.user import User
 
-__all__ = ["Permission", "RolePermission", "UserRole", "RefreshToken", "Role", "Tenant", "TenantInvitation", "TenantMember", "User"]
+__all__ = [
+    "EmailVerificationToken",
+    "PasswordResetToken",
+    "Permission",
+    "RolePermission",
+    "UserRole",
+    "RefreshToken",
+    "Role",
+    "Tenant",
+    "TenantInvitation",
+    "TenantMember",
+    "User",
+]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,5 @@
+from app.models.permission import Permission
+from app.models.rbac import RolePermission, UserRole
 from app.models.refresh_token import RefreshToken
 from app.models.role import Role
 from app.models.tenant import Tenant
@@ -5,4 +7,4 @@ from app.models.tenant_invitation import TenantInvitation
 from app.models.tenant_member import TenantMember
 from app.models.user import User
 
-__all__ = ["RefreshToken", "Role", "Tenant", "TenantInvitation", "TenantMember", "User"]
+__all__ = ["Permission", "RolePermission", "UserRole", "RefreshToken", "Role", "Tenant", "TenantInvitation", "TenantMember", "User"]

--- a/app/models/email_verification_token.py
+++ b/app/models/email_verification_token.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class EmailVerificationToken(Base):
+    __tablename__ = "email_verification_tokens"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/password_reset_token.py
+++ b/app/models/password_reset_token.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/permission.py
+++ b/app/models/permission.py
@@ -1,0 +1,17 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Permission(Base):
+    __tablename__ = "permissions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    description: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/rbac.py
+++ b/app/models/rbac.py
@@ -1,0 +1,21 @@
+import uuid
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class RolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True)
+    permission_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True)
+
+
+class UserRole(Base):
+    __tablename__ = "user_roles"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True)

--- a/app/models/rbac.py
+++ b/app/models/rbac.py
@@ -1,6 +1,8 @@
+# pyright: reportUnannotatedClassAttribute=false, reportAny=false
 import uuid
+from datetime import datetime
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -16,6 +18,10 @@ class RolePermission(Base):
 
 class UserRole(Base):
     __tablename__ = "user_roles"
+    __table_args__ = (UniqueConstraint("user_id", "role_id", "tenant_id", name="uq_user_roles_user_id_role_id_tenant_id"),)
 
-    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
-    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    role_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="CASCADE"), nullable=False)
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/role.py
+++ b/app/models/role.py
@@ -1,10 +1,11 @@
+# pyright: reportUnannotatedClassAttribute=false
 from __future__ import annotations
 
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import Boolean, DateTime, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -21,6 +22,7 @@ class Role(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     description: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_tenant_role: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     tenant_invitations: Mapped[list["TenantInvitation"]] = relationship(back_populates="role")

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,75 +1,253 @@
+# pyright: reportCallInDefaultInitializer=false, reportUnusedCallResult=false
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db_session
-from app.middleware.auth import get_current_user, require_permission
+from app.middleware.auth import get_user_permission_names, require_permission
 from app.models.permission import Permission
 from app.models.rbac import RolePermission, UserRole
 from app.models.role import Role
+from app.models.tenant_member import TenantMember
 from app.models.user import User
 from app.schemas.rbac import (
+    PermissionCreateRequest,
     PermissionResponse,
+    PermissionUpdateRequest,
+    RoleCreateRequest,
     RolePermissionRequest,
     RoleResponse,
+    RoleUpdateRequest,
     UserListResponse,
     UserRoleRequest,
     UserUpdateRequest,
 )
 from app.utils.errors import AppError
 
-router = APIRouter(prefix="/api/v1", tags=["admin"])
+
+SYSTEM_ROLE_NAMES = {"super_admin", "admin", "user", "tenant_admin", "tenant_member"}
+
+router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
 
-@router.get("/admin/roles", response_model=list[RoleResponse])
+def _tenant_id_from_request(request: Request) -> UUID | None:
+    return getattr(request.state, "tenant_id", None)
+
+
+async def _get_role(session: AsyncSession, role_id: UUID) -> Role:
+    role = await session.scalar(select(Role).where(Role.id == role_id))
+    if role is None:
+        raise AppError(404, "ROLE_NOT_FOUND", "Role not found.")
+    return role
+
+
+async def _get_permission(session: AsyncSession, permission_id: UUID) -> Permission:
+    permission = await session.scalar(select(Permission).where(Permission.id == permission_id))
+    if permission is None:
+        raise AppError(404, "PERMISSION_NOT_FOUND", "Permission not found.")
+    return permission
+
+
+async def _get_tenant_membership(session: AsyncSession, user_id: UUID, tenant_id: UUID) -> TenantMember:
+    membership = await session.scalar(
+        select(TenantMember).where(
+            TenantMember.user_id == user_id,
+            TenantMember.tenant_id == tenant_id,
+        )
+    )
+    if membership is None:
+        raise AppError(404, "TENANT_MEMBER_NOT_FOUND", "Tenant member not found.")
+    return membership
+
+
+async def _get_user_for_scope(session: AsyncSession, user_id: UUID, tenant_id: UUID | None) -> User:
+    if tenant_id is None:
+        user = await session.scalar(select(User).where(User.id == user_id))
+    else:
+        user = await session.scalar(
+            select(User)
+            .join(TenantMember, TenantMember.user_id == User.id)
+            .where(
+                User.id == user_id,
+                TenantMember.tenant_id == tenant_id,
+                TenantMember.is_active.is_(True),
+            )
+        )
+    if user is None:
+        raise AppError(404, "USER_NOT_FOUND", "User not found.")
+    return user
+
+
+async def _serialize_user(session: AsyncSession, user: User, tenant_id: UUID | None) -> UserListResponse:
+    global_roles = await session.scalars(
+        select(Role.name)
+        .join(UserRole, UserRole.role_id == Role.id)
+        .where(UserRole.user_id == user.id, UserRole.tenant_id.is_(None))
+        .order_by(Role.name)
+    )
+    tenant_role_name = None
+    if tenant_id is not None:
+        tenant_role_name = await session.scalar(
+            select(Role.name)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .where(UserRole.user_id == user.id, UserRole.tenant_id == tenant_id, Role.is_tenant_role.is_(True))
+            .order_by(Role.name)
+        )
+    return UserListResponse(
+        id=user.id,
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        is_active=user.is_active,
+        is_verified=user.is_verified,
+        created_at=user.created_at,
+        updated_at=user.updated_at,
+        tenant_id=tenant_id,
+        tenant_role_name=tenant_role_name,
+        global_roles=list(global_roles),
+    )
+
+
+async def _get_scoped_permissions(session: AsyncSession, user_id: UUID, tenant_id: UUID | None) -> list[Permission]:
+    permission_names = await get_user_permission_names(session, user_id, tenant_id=tenant_id)
+    if not permission_names:
+        return []
+    permissions = await session.scalars(select(Permission).where(Permission.name.in_(permission_names)).order_by(Permission.name))
+    return list(permissions)
+
+
+async def _ensure_role_matches_scope(session: AsyncSession, role_id: UUID, tenant_id: UUID | None) -> Role:
+    role = await _get_role(session, role_id)
+    if tenant_id is None and role.is_tenant_role:
+        raise AppError(400, "INVALID_ROLE_SCOPE", "Tenant roles can only be assigned in tenant context.")
+    if tenant_id is not None and not role.is_tenant_role:
+        raise AppError(400, "INVALID_ROLE_SCOPE", "Global roles cannot be assigned in tenant context.")
+    return role
+
+
+async def _get_default_tenant_member_role(session: AsyncSession) -> Role:
+    role = await session.scalar(select(Role).where(Role.name == "tenant_member", Role.is_tenant_role.is_(True)))
+    if role is None:
+        raise AppError(500, "ROLE_NOT_FOUND", "Default tenant member role has not been seeded.")
+    return role
+
+
+@router.get("/roles", response_model=list[RoleResponse])
 async def list_roles(
     session: AsyncSession = Depends(get_db_session),
-    _: User = Depends(require_permission("roles.manage")),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
 ):
-    roles = await session.scalars(select(Role).order_by(Role.name))
+    roles = await session.scalars(select(Role).order_by(Role.is_tenant_role, Role.name))
     return list(roles)
 
 
-@router.get("/admin/roles/{role_id}/permissions", response_model=list[PermissionResponse])
+@router.post("/roles", response_model=RoleResponse)
+async def create_role(
+    payload: RoleCreateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
+):
+    name = payload.name.strip().lower()
+    exists = await session.scalar(select(Role).where(Role.name == name))
+    if exists is not None:
+        raise AppError(409, "ROLE_ALREADY_EXISTS", "A role with this name already exists.")
+    role = Role(name=name, description=payload.description.strip(), is_tenant_role=payload.is_tenant_role)
+    session.add(role)
+    await session.commit()
+    await session.refresh(role)
+    return role
+
+
+@router.get("/roles/{role_id}", response_model=RoleResponse)
+async def get_role(
+    role_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
+):
+    return await _get_role(session, role_id)
+
+
+@router.patch("/roles/{role_id}", response_model=RoleResponse)
+async def update_role(
+    role_id: UUID,
+    payload: RoleUpdateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
+):
+    role = await _get_role(session, role_id)
+    if role.name in SYSTEM_ROLE_NAMES and payload.name and payload.name.strip().lower() != role.name:
+        raise AppError(400, "SYSTEM_ROLE_LOCKED", "System role names cannot be changed.")
+    if payload.name is not None:
+        new_name = payload.name.strip().lower()
+        existing = await session.scalar(select(Role).where(Role.name == new_name, Role.id != role.id))
+        if existing is not None:
+            raise AppError(409, "ROLE_ALREADY_EXISTS", "A role with this name already exists.")
+        role.name = new_name
+    if payload.description is not None:
+        role.description = payload.description.strip()
+    await session.commit()
+    await session.refresh(role)
+    return role
+
+
+@router.delete("/roles/{role_id}", response_model=dict)
+async def delete_role(
+    role_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
+):
+    role = await _get_role(session, role_id)
+    if role.name in SYSTEM_ROLE_NAMES:
+        raise AppError(400, "SYSTEM_ROLE_LOCKED", "System roles cannot be deleted.")
+    await session.delete(role)
+    await session.commit()
+    return {"data": {"message": "Role deleted."}}
+
+
+@router.get("/roles/{role_id}/permissions", response_model=list[PermissionResponse])
 async def get_role_permissions(
     role_id: UUID,
     session: AsyncSession = Depends(get_db_session),
-    _: User = Depends(require_permission("roles.manage")),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
 ):
+    await _get_role(session, role_id)
     permissions = await session.scalars(
         select(Permission)
         .join(RolePermission, RolePermission.permission_id == Permission.id)
         .where(RolePermission.role_id == role_id)
+        .order_by(Permission.name)
     )
     return list(permissions)
 
 
-@router.post("/admin/roles/permissions", response_model=dict)
+@router.post("/roles/permissions", response_model=dict)
 async def assign_permission_to_role(
     payload: RolePermissionRequest,
     session: AsyncSession = Depends(get_db_session),
-    _: User = Depends(require_permission("roles.manage")),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
 ):
+    await _get_role(session, payload.role_id)
+    await _get_permission(session, payload.permission_id)
     exists = await session.scalar(
         select(RolePermission).where(
             RolePermission.role_id == payload.role_id,
             RolePermission.permission_id == payload.permission_id,
         )
     )
-    if exists:
+    if exists is not None:
         raise AppError(409, "ALREADY_EXISTS", "Permission already assigned to this role.")
     session.add(RolePermission(role_id=payload.role_id, permission_id=payload.permission_id))
     await session.commit()
     return {"data": {"message": "Permission assigned to role."}}
 
 
-@router.delete("/admin/roles/permissions", response_model=dict)
+@router.delete("/roles/permissions", response_model=dict)
 async def remove_permission_from_role(
     payload: RolePermissionRequest,
     session: AsyncSession = Depends(get_db_session),
-    _: User = Depends(require_permission("roles.manage")),
+    _: User = Depends(require_permission("roles.manage", global_only=True)),
 ):
     await session.execute(
         delete(RolePermission).where(
@@ -81,112 +259,237 @@ async def remove_permission_from_role(
     return {"data": {"message": "Permission removed from role."}}
 
 
-@router.get("/admin/permissions", response_model=list[PermissionResponse])
+@router.get("/permissions", response_model=list[PermissionResponse])
 async def list_permissions(
     session: AsyncSession = Depends(get_db_session),
-    _: User = Depends(require_permission("roles.manage")),
+    _: User = Depends(require_permission("permissions.manage", global_only=True)),
 ):
     permissions = await session.scalars(select(Permission).order_by(Permission.name))
     return list(permissions)
 
 
-@router.get("/admin/users", response_model=list[UserListResponse])
+@router.post("/permissions", response_model=PermissionResponse)
+async def create_permission(
+    payload: PermissionCreateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("permissions.manage", global_only=True)),
+):
+    name = payload.name.strip().lower()
+    exists = await session.scalar(select(Permission).where(Permission.name == name))
+    if exists is not None:
+        raise AppError(409, "PERMISSION_ALREADY_EXISTS", "A permission with this name already exists.")
+    permission = Permission(name=name, description=payload.description.strip())
+    session.add(permission)
+    await session.commit()
+    await session.refresh(permission)
+    return permission
+
+
+@router.get("/permissions/{permission_id}", response_model=PermissionResponse)
+async def get_permission(
+    permission_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("permissions.manage", global_only=True)),
+):
+    return await _get_permission(session, permission_id)
+
+
+@router.patch("/permissions/{permission_id}", response_model=PermissionResponse)
+async def update_permission(
+    permission_id: UUID,
+    payload: PermissionUpdateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("permissions.manage", global_only=True)),
+):
+    permission = await _get_permission(session, permission_id)
+    if payload.name is not None:
+        new_name = payload.name.strip().lower()
+        existing = await session.scalar(select(Permission).where(Permission.name == new_name, Permission.id != permission.id))
+        if existing is not None:
+            raise AppError(409, "PERMISSION_ALREADY_EXISTS", "A permission with this name already exists.")
+        permission.name = new_name
+    if payload.description is not None:
+        permission.description = payload.description.strip()
+    await session.commit()
+    await session.refresh(permission)
+    return permission
+
+
+@router.delete("/permissions/{permission_id}", response_model=dict)
+async def delete_permission(
+    permission_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("permissions.manage", global_only=True)),
+):
+    permission = await _get_permission(session, permission_id)
+    await session.delete(permission)
+    await session.commit()
+    return {"data": {"message": "Permission deleted."}}
+
+
+@router.get("/users", response_model=list[UserListResponse])
 async def list_users(
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("users.read")),
 ):
-    users = await session.scalars(select(User).order_by(User.created_at.desc()))
-    return list(users)
+    tenant_id = _tenant_id_from_request(request)
+    if tenant_id is None:
+        users = list(await session.scalars(select(User).order_by(User.created_at.desc())))
+    else:
+        result = await session.execute(
+            select(User)
+            .join(TenantMember, TenantMember.user_id == User.id)
+            .where(TenantMember.tenant_id == tenant_id, TenantMember.is_active.is_(True))
+            .order_by(TenantMember.joined_at.desc())
+        )
+        users = list(result.scalars().unique().all())
+    return [await _serialize_user(session, user, tenant_id) for user in users]
 
 
-@router.get("/admin/users/{user_id}", response_model=UserListResponse)
+@router.get("/users/{user_id}", response_model=UserListResponse)
 async def get_user(
     user_id: UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("users.read")),
 ):
-    user = await session.scalar(select(User).where(User.id == user_id))
-    if user is None:
-        raise AppError(404, "USER_NOT_FOUND", "User not found.")
-    return user
+    tenant_id = _tenant_id_from_request(request)
+    user = await _get_user_for_scope(session, user_id, tenant_id)
+    return await _serialize_user(session, user, tenant_id)
 
 
-@router.patch("/admin/users/{user_id}", response_model=UserListResponse)
+@router.patch("/users/{user_id}", response_model=UserListResponse)
 async def update_user(
     user_id: UUID,
     payload: UserUpdateRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("users.write")),
 ):
-    user = await session.scalar(select(User).where(User.id == user_id))
-    if user is None:
-        raise AppError(404, "USER_NOT_FOUND", "User not found.")
-    for field, value in payload.model_dump(exclude_unset=True).items():
-        setattr(user, field, value)
+    tenant_id = _tenant_id_from_request(request)
+    user = await _get_user_for_scope(session, user_id, tenant_id)
+    if payload.first_name is not None:
+        user.first_name = payload.first_name.strip()
+    if payload.last_name is not None:
+        user.last_name = payload.last_name.strip()
+    if tenant_id is None:
+        if payload.is_active is not None:
+            user.is_active = payload.is_active
+    else:
+        membership = await _get_tenant_membership(session, user_id, tenant_id)
+        if payload.is_active is not None:
+            membership.is_active = payload.is_active
     await session.commit()
     await session.refresh(user)
-    return user
+    return await _serialize_user(session, user, tenant_id)
 
 
-@router.delete("/admin/users/{user_id}", response_model=dict)
+@router.delete("/users/{user_id}", response_model=dict)
 async def delete_user(
     user_id: UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("users.delete")),
 ):
-    user = await session.scalar(select(User).where(User.id == user_id))
-    if user is None:
-        raise AppError(404, "USER_NOT_FOUND", "User not found.")
-    await session.delete(user)
+    tenant_id = _tenant_id_from_request(request)
+    if tenant_id is None:
+        user = await _get_user_for_scope(session, user_id, None)
+        await session.delete(user)
+        message = "User deleted."
+    else:
+        membership = await _get_tenant_membership(session, user_id, tenant_id)
+        membership.is_active = False
+        await session.execute(delete(UserRole).where(UserRole.user_id == user_id, UserRole.tenant_id == tenant_id))
+        message = "User removed from tenant."
     await session.commit()
-    return {"data": {"message": "User deleted."}}
+    return {"data": {"message": message}}
 
 
-@router.post("/admin/users/roles", response_model=dict)
+@router.post("/users/roles", response_model=dict)
 async def assign_role_to_user(
     payload: UserRoleRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("roles.manage")),
 ):
-    exists = await session.scalar(
-        select(UserRole).where(
-            UserRole.user_id == payload.user_id,
-            UserRole.role_id == payload.role_id,
+    tenant_id = _tenant_id_from_request(request)
+    await _get_user_for_scope(session, payload.user_id, tenant_id)
+    role = await _ensure_role_matches_scope(session, payload.role_id, tenant_id)
+
+    if tenant_id is None:
+        exists = await session.scalar(
+            select(UserRole).where(
+                UserRole.user_id == payload.user_id,
+                UserRole.role_id == payload.role_id,
+                UserRole.tenant_id.is_(None),
+            )
         )
-    )
-    if exists:
-        raise AppError(409, "ALREADY_EXISTS", "Role already assigned to this user.")
-    session.add(UserRole(user_id=payload.user_id, role_id=payload.role_id))
+        if exists is not None:
+            raise AppError(409, "ALREADY_EXISTS", "Role already assigned to this user.")
+        session.add(UserRole(user_id=payload.user_id, role_id=payload.role_id, tenant_id=None))
+    else:
+        membership = await _get_tenant_membership(session, payload.user_id, tenant_id)
+        current_assignment = await session.scalar(
+            select(UserRole).where(
+                UserRole.user_id == payload.user_id,
+                UserRole.role_id == payload.role_id,
+                UserRole.tenant_id == tenant_id,
+            )
+        )
+        if current_assignment is not None and membership.role_id == payload.role_id:
+            raise AppError(409, "ALREADY_EXISTS", "Role already assigned to this tenant member.")
+        await session.execute(delete(UserRole).where(UserRole.user_id == payload.user_id, UserRole.tenant_id == tenant_id))
+        session.add(UserRole(user_id=payload.user_id, role_id=payload.role_id, tenant_id=tenant_id))
+        membership.role_id = role.id
+
     await session.commit()
     return {"data": {"message": "Role assigned to user."}}
 
 
-@router.delete("/admin/users/roles", response_model=dict)
+@router.delete("/users/roles", response_model=dict)
 async def remove_role_from_user(
     payload: UserRoleRequest,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("roles.manage")),
 ):
-    await session.execute(
-        delete(UserRole).where(
-            UserRole.user_id == payload.user_id,
-            UserRole.role_id == payload.role_id,
+    tenant_id = _tenant_id_from_request(request)
+
+    if tenant_id is None:
+        assignment = await session.scalar(
+            select(UserRole).where(
+                UserRole.user_id == payload.user_id,
+                UserRole.role_id == payload.role_id,
+                UserRole.tenant_id.is_(None),
+            )
         )
-    )
+        if assignment is None:
+            raise AppError(404, "USER_ROLE_NOT_FOUND", "Role assignment not found.")
+        await session.delete(assignment)
+        message = "Role removed from user."
+    else:
+        membership = await _get_tenant_membership(session, payload.user_id, tenant_id)
+        fallback_role = await _get_default_tenant_member_role(session)
+        if payload.role_id == fallback_role.id and membership.role_id == fallback_role.id:
+            raise AppError(400, "BASE_TENANT_ROLE_REQUIRED", "Tenant members must keep a tenant role assignment.")
+        await session.execute(delete(UserRole).where(UserRole.user_id == payload.user_id, UserRole.role_id == payload.role_id, UserRole.tenant_id == tenant_id))
+        await session.execute(delete(UserRole).where(UserRole.user_id == payload.user_id, UserRole.tenant_id == tenant_id))
+        session.add(UserRole(user_id=payload.user_id, role_id=fallback_role.id, tenant_id=tenant_id))
+        membership.role_id = fallback_role.id
+        message = "Tenant role reset to tenant_member."
+
     await session.commit()
-    return {"data": {"message": "Role removed from user."}}
+    return {"data": {"message": message}}
 
 
-@router.get("/admin/users/{user_id}/permissions", response_model=list[PermissionResponse])
+@router.get("/users/{user_id}/permissions", response_model=list[PermissionResponse])
 async def get_user_permissions(
     user_id: UUID,
+    request: Request,
     session: AsyncSession = Depends(get_db_session),
     _: User = Depends(require_permission("users.read")),
 ):
-    permissions = await session.scalars(
-        select(Permission)
-        .join(RolePermission, RolePermission.permission_id == Permission.id)
-        .join(UserRole, UserRole.role_id == RolePermission.role_id)
-        .where(UserRole.user_id == user_id)
-    )
-    return list(permissions)
+    tenant_id = _tenant_id_from_request(request)
+    await _get_user_for_scope(session, user_id, tenant_id)
+    return await _get_scoped_permissions(session, user_id, tenant_id)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,0 +1,192 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db_session
+from app.middleware.auth import get_current_user, require_permission
+from app.models.permission import Permission
+from app.models.rbac import RolePermission, UserRole
+from app.models.role import Role
+from app.models.user import User
+from app.schemas.rbac import (
+    PermissionResponse,
+    RolePermissionRequest,
+    RoleResponse,
+    UserListResponse,
+    UserRoleRequest,
+    UserUpdateRequest,
+)
+from app.utils.errors import AppError
+
+router = APIRouter(prefix="/api/v1", tags=["admin"])
+
+
+@router.get("/admin/roles", response_model=list[RoleResponse])
+async def list_roles(
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    roles = await session.scalars(select(Role).order_by(Role.name))
+    return list(roles)
+
+
+@router.get("/admin/roles/{role_id}/permissions", response_model=list[PermissionResponse])
+async def get_role_permissions(
+    role_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    permissions = await session.scalars(
+        select(Permission)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)
+        .where(RolePermission.role_id == role_id)
+    )
+    return list(permissions)
+
+
+@router.post("/admin/roles/permissions", response_model=dict)
+async def assign_permission_to_role(
+    payload: RolePermissionRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    exists = await session.scalar(
+        select(RolePermission).where(
+            RolePermission.role_id == payload.role_id,
+            RolePermission.permission_id == payload.permission_id,
+        )
+    )
+    if exists:
+        raise AppError(409, "ALREADY_EXISTS", "Permission already assigned to this role.")
+    session.add(RolePermission(role_id=payload.role_id, permission_id=payload.permission_id))
+    await session.commit()
+    return {"data": {"message": "Permission assigned to role."}}
+
+
+@router.delete("/admin/roles/permissions", response_model=dict)
+async def remove_permission_from_role(
+    payload: RolePermissionRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    await session.execute(
+        delete(RolePermission).where(
+            RolePermission.role_id == payload.role_id,
+            RolePermission.permission_id == payload.permission_id,
+        )
+    )
+    await session.commit()
+    return {"data": {"message": "Permission removed from role."}}
+
+
+@router.get("/admin/permissions", response_model=list[PermissionResponse])
+async def list_permissions(
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    permissions = await session.scalars(select(Permission).order_by(Permission.name))
+    return list(permissions)
+
+
+@router.get("/admin/users", response_model=list[UserListResponse])
+async def list_users(
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("users.read")),
+):
+    users = await session.scalars(select(User).order_by(User.created_at.desc()))
+    return list(users)
+
+
+@router.get("/admin/users/{user_id}", response_model=UserListResponse)
+async def get_user(
+    user_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("users.read")),
+):
+    user = await session.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise AppError(404, "USER_NOT_FOUND", "User not found.")
+    return user
+
+
+@router.patch("/admin/users/{user_id}", response_model=UserListResponse)
+async def update_user(
+    user_id: UUID,
+    payload: UserUpdateRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("users.write")),
+):
+    user = await session.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise AppError(404, "USER_NOT_FOUND", "User not found.")
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(user, field, value)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@router.delete("/admin/users/{user_id}", response_model=dict)
+async def delete_user(
+    user_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("users.delete")),
+):
+    user = await session.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise AppError(404, "USER_NOT_FOUND", "User not found.")
+    await session.delete(user)
+    await session.commit()
+    return {"data": {"message": "User deleted."}}
+
+
+@router.post("/admin/users/roles", response_model=dict)
+async def assign_role_to_user(
+    payload: UserRoleRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    exists = await session.scalar(
+        select(UserRole).where(
+            UserRole.user_id == payload.user_id,
+            UserRole.role_id == payload.role_id,
+        )
+    )
+    if exists:
+        raise AppError(409, "ALREADY_EXISTS", "Role already assigned to this user.")
+    session.add(UserRole(user_id=payload.user_id, role_id=payload.role_id))
+    await session.commit()
+    return {"data": {"message": "Role assigned to user."}}
+
+
+@router.delete("/admin/users/roles", response_model=dict)
+async def remove_role_from_user(
+    payload: UserRoleRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("roles.manage")),
+):
+    await session.execute(
+        delete(UserRole).where(
+            UserRole.user_id == payload.user_id,
+            UserRole.role_id == payload.role_id,
+        )
+    )
+    await session.commit()
+    return {"data": {"message": "Role removed from user."}}
+
+
+@router.get("/admin/users/{user_id}/permissions", response_model=list[PermissionResponse])
+async def get_user_permissions(
+    user_id: UUID,
+    session: AsyncSession = Depends(get_db_session),
+    _: User = Depends(require_permission("users.read")),
+):
+    permissions = await session.scalars(
+        select(Permission)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)
+        .join(UserRole, UserRole.role_id == RolePermission.role_id)
+        .where(UserRole.user_id == user_id)
+    )
+    return list(permissions)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,3 +1,4 @@
+# pyright: reportCallInDefaultInitializer=false
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request, status

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -7,6 +7,7 @@ from app.deps import get_db_session
 from app.middleware.auth import get_current_user
 from app.models.user import User
 from app.schemas.auth import AuthUserResponse, LoginRequest, LogoutRequest, MessageResponse, RefreshTokenRequest, RegisterRequest, TokenResponse
+from app.schemas.extended_auth import ForgotPasswordRequest, ResetPasswordRequest, VerifyEmailRequest
 from app.schemas.user import UserResponse
 from app.services.auth_service import AuthService
 from app.utils.errors import AppError
@@ -50,3 +51,21 @@ async def refresh(payload: RefreshTokenRequest, session: AsyncSession = Depends(
 @router.get("/me", response_model=UserResponse)
 async def me(current_user: User = Depends(get_current_user)):
     return {"data": current_user}
+
+
+@router.post("/verify-email", response_model=MessageResponse)
+async def verify_email(payload: VerifyEmailRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).verify_email(payload.token)
+    return {"data": {"message": "Email verified successfully."}}
+
+
+@router.post("/forgot-password", response_model=MessageResponse)
+async def forgot_password(payload: ForgotPasswordRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).forgot_password(payload.email)
+    return {"data": {"message": "If an account with that email exists, a reset link has been sent."}}
+
+
+@router.post("/reset-password", response_model=MessageResponse)
+async def reset_password(payload: ResetPasswordRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).reset_password(payload.token, payload.new_password)
+    return {"data": {"message": "Password reset successfully."}}

--- a/app/schemas/extended_auth.py
+++ b/app/schemas/extended_auth.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, EmailStr
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str

--- a/app/schemas/extended_auth.py
+++ b/app/schemas/extended_auth.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class VerifyEmailRequest(BaseModel):
-    token: str
+    token: str = Field(min_length=1)
 
 
 class ForgotPasswordRequest(BaseModel):
@@ -10,5 +10,5 @@ class ForgotPasswordRequest(BaseModel):
 
 
 class ResetPasswordRequest(BaseModel):
-    token: str
-    new_password: str
+    token: str = Field(min_length=1)
+    new_password: str = Field(min_length=8, max_length=128)

--- a/app/schemas/rbac.py
+++ b/app/schemas/rbac.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class RoleResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PermissionResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RolePermissionRequest(BaseModel):
+    role_id: uuid.UUID
+    permission_id: uuid.UUID
+
+
+class UserRoleRequest(BaseModel):
+    user_id: uuid.UUID
+    role_id: uuid.UUID
+
+
+class UserListResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    first_name: str
+    last_name: str
+    is_active: bool
+    is_verified: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserUpdateRequest(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    is_active: bool | None = None

--- a/app/schemas/rbac.py
+++ b/app/schemas/rbac.py
@@ -1,16 +1,29 @@
+# pyright: reportUnannotatedClassAttribute=false
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class RoleResponse(BaseModel):
     id: uuid.UUID
     name: str
     description: str
+    is_tenant_role: bool
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class RoleCreateRequest(BaseModel):
+    name: str = Field(min_length=3, max_length=50)
+    description: str = Field(min_length=3, max_length=255)
+    is_tenant_role: bool = False
+
+
+class RoleUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=3, max_length=50)
+    description: str | None = Field(default=None, min_length=3, max_length=255)
 
 
 class PermissionResponse(BaseModel):
@@ -20,6 +33,16 @@ class PermissionResponse(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class PermissionCreateRequest(BaseModel):
+    name: str = Field(min_length=3, max_length=100)
+    description: str = Field(min_length=3, max_length=255)
+
+
+class PermissionUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=3, max_length=100)
+    description: str | None = Field(default=None, min_length=3, max_length=255)
 
 
 class RolePermissionRequest(BaseModel):
@@ -41,11 +64,12 @@ class UserListResponse(BaseModel):
     is_verified: bool
     created_at: datetime
     updated_at: datetime
-
-    model_config = {"from_attributes": True}
+    tenant_id: uuid.UUID | None = None
+    tenant_role_name: str | None = None
+    global_roles: list[str] = Field(default_factory=list)
 
 
 class UserUpdateRequest(BaseModel):
-    first_name: str | None = None
-    last_name: str | None = None
+    first_name: str | None = Field(default=None, min_length=1, max_length=100)
+    last_name: str | None = Field(default=None, min_length=1, max_length=100)
     is_active: bool | None = None

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,11 +1,16 @@
+# pyright: reportUnannotatedClassAttribute=false, reportUnusedCallResult=false
 from datetime import UTC, datetime
 
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.email_verification_token import EmailVerificationToken
+from app.models.password_reset_token import PasswordResetToken
 from app.models.refresh_token import RefreshToken
+from app.models.rbac import UserRole
+from app.models.role import Role
 from app.models.tenant_member import TenantMember
 from app.models.user import User
 from app.schemas.auth import LoginRequest, RegisterRequest, TokenData
@@ -32,10 +37,16 @@ class AuthService:
             last_name=payload.last_name.strip(),
         )
         self.session.add(user)
+        await self.session.flush()
+
+        default_role = await self.session.scalar(select(Role).where(Role.name == "user"))
+        if default_role is None:
+            raise AppError(500, "ROLE_NOT_FOUND", "Default user role has not been seeded.")
+        self.session.add(UserRole(user_id=user.id, role_id=default_role.id, tenant_id=None))
+
+        verification_token = await self._issue_email_verification_token(user.id)
         await self.session.commit()
         await self.session.refresh(user)
-
-        verification_token = self.token_service.create_verification_token(str(user.id), user.email)
         await send_email(
             recipient=user.email,
             subject="Verify your account",
@@ -107,20 +118,22 @@ class AuthService:
             raise AppError(403, "TENANT_ACCESS_DENIED", "User does not belong to this tenant.")
 
     async def verify_email(self, token: str) -> None:
-        payload = self.token_service.decode_token(token, expected_type="verify")
-        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        token_record = await self._get_valid_email_verification_token(token)
+        user = await self.session.scalar(select(User).where(User.id == token_record.user_id))
         if user is None:
             raise AppError(404, "USER_NOT_FOUND", "User not found.")
         if user.is_verified:
             raise AppError(400, "ALREADY_VERIFIED", "Email is already verified.")
         user.is_verified = True
+        token_record.used_at = datetime.now(UTC)
         await self.session.commit()
 
     async def forgot_password(self, email: str) -> None:
         user = await self.session.scalar(select(User).where(User.email == email.lower()))
         if user is None:
             return
-        reset_token = self.token_service.create_verification_token(str(user.id), user.email)
+        reset_token = await self._issue_password_reset_token(user.id)
+        await self.session.commit()
         await send_email(
             recipient=user.email,
             subject="Password Reset",
@@ -128,9 +141,61 @@ class AuthService:
         )
 
     async def reset_password(self, token: str, new_password: str) -> None:
-        payload = self.token_service.decode_token(token, expected_type="verify")
-        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        token_record = await self._get_valid_password_reset_token(token)
+        user = await self.session.scalar(select(User).where(User.id == token_record.user_id))
         if user is None:
             raise AppError(404, "USER_NOT_FOUND", "User not found.")
         user.password_hash = hash_password(new_password)
+        token_record.used_at = datetime.now(UTC)
+        await self.session.execute(
+            update(RefreshToken)
+            .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(UTC))
+        )
         await self.session.commit()
+
+    async def _issue_email_verification_token(self, user_id: UUID) -> str:
+        token = self.token_service.create_one_time_token()
+        self.session.add(
+            EmailVerificationToken(
+                user_id=user_id,
+                token_hash=self.token_service.hash_token(token),
+                expires_at=datetime.now(UTC) + self.token_service.verification_token_lifetime,
+            )
+        )
+        await self.session.flush()
+        return token
+
+    async def _issue_password_reset_token(self, user_id: UUID) -> str:
+        token = self.token_service.create_one_time_token()
+        self.session.add(
+            PasswordResetToken(
+                user_id=user_id,
+                token_hash=self.token_service.hash_token(token),
+                expires_at=datetime.now(UTC) + self.token_service.password_reset_token_lifetime,
+            )
+        )
+        await self.session.flush()
+        return token
+
+    async def _get_valid_email_verification_token(self, token: str) -> EmailVerificationToken:
+        token_record = await self.session.scalar(
+            select(EmailVerificationToken).where(
+                EmailVerificationToken.token_hash == self.token_service.hash_token(token),
+                EmailVerificationToken.used_at.is_(None),
+            )
+        )
+        if token_record is None or token_record.expires_at <= datetime.now(UTC):
+            raise AppError(400, "INVALID_VERIFICATION_TOKEN", "Verification token is invalid or expired.")
+        return token_record
+
+    async def _get_valid_password_reset_token(self, token: str) -> PasswordResetToken:
+        token_record = await self.session.scalar(
+            select(PasswordResetToken).where(
+                PasswordResetToken.token_hash == self.token_service.hash_token(token),
+                PasswordResetToken.used_at.is_(None),
+            )
+        )
+        if token_record is None or token_record.expires_at <= datetime.now(UTC):
+            raise AppError(400, "INVALID_PASSWORD_RESET_TOKEN", "Password reset token is invalid or expired.")
+        return token_record

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -105,3 +105,32 @@ class AuthService:
         )
         if membership is None:
             raise AppError(403, "TENANT_ACCESS_DENIED", "User does not belong to this tenant.")
+
+    async def verify_email(self, token: str) -> None:
+        payload = self.token_service.decode_token(token, expected_type="verify")
+        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        if user is None:
+            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+        if user.is_verified:
+            raise AppError(400, "ALREADY_VERIFIED", "Email is already verified.")
+        user.is_verified = True
+        await self.session.commit()
+
+    async def forgot_password(self, email: str) -> None:
+        user = await self.session.scalar(select(User).where(User.email == email.lower()))
+        if user is None:
+            return
+        reset_token = self.token_service.create_verification_token(str(user.id), user.email)
+        await send_email(
+            recipient=user.email,
+            subject="Password Reset",
+            body=f"Your password reset token is: {reset_token}",
+        )
+
+    async def reset_password(self, token: str, new_password: str) -> None:
+        payload = self.token_service.decode_token(token, expected_type="verify")
+        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        if user is None:
+            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+        user.password_hash = hash_password(new_password)
+        await self.session.commit()

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,6 +1,8 @@
+# pyright: reportUnannotatedClassAttribute=false, reportUnknownMemberType=false, reportAny=false
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
+import secrets
 from uuid import UUID
 
 import jwt
@@ -22,6 +24,8 @@ class TokenPayload:
 class TokenService:
     def __init__(self):
         self.settings = get_settings()
+        self.verification_token_lifetime = timedelta(hours=24)
+        self.password_reset_token_lifetime = timedelta(hours=2)
 
     def create_access_token(self, user_id: str, tenant_id: UUID | None = None) -> tuple[str, datetime]:
         expires_at = datetime.now(UTC) + timedelta(minutes=self.settings.jwt_access_expire_minutes)
@@ -39,13 +43,8 @@ class TokenService:
         token = jwt.encode(payload, self.settings.jwt_secret, algorithm=self.settings.jwt_algorithm)
         return token, expires_at
 
-    def create_verification_token(self, user_id: str, email: str) -> str:
-        expires_at = datetime.now(UTC) + timedelta(hours=24)
-        return jwt.encode(
-            {"sub": user_id, "email": email, "type": "verify", "exp": expires_at},
-            self.settings.jwt_secret,
-            algorithm=self.settings.jwt_algorithm,
-        )
+    def create_one_time_token(self) -> str:
+        return secrets.token_urlsafe(32)
 
     async def issue_token_pair(self, session: AsyncSession, user_id: UUID, tenant_id: UUID | None = None) -> TokenData:
         access_token, _ = self.create_access_token(str(user_id), tenant_id=tenant_id)


### PR DESCRIPTION
## Summary
- add persisted email verification and password reset flows with hashed one-time tokens, seeded default user roles, and refresh token revocation on password reset
- add tenant-aware RBAC foundations with scoped user role assignments, seeded global and tenant permissions, and middleware that resolves permissions by tenant context
- expand admin APIs for roles, permissions, and user management, including tenant-scoped user listing and role assignment behavior

## Verification
- `lsp_diagnostics` clean on changed application files
- `docker-compose up --build -d` and `/health` check on port 8002
- `curl` tested register, verify-email, forgot-password, reset-password, global admin role/permission/user endpoints, tenant-scoped login, tenant user listing, tenant role assignment, and tenant permission resolution
- `docker-compose down -v`