### PR TITLE
feat: add email verification and password reset

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from app.config import get_settings
 from app.database import Base
-from app.models import refresh_token, role, tenant, tenant_invitation, tenant_member, user  # noqa: F401
+from app.models import email_verification_token, password_reset_token, refresh_token, role, tenant, tenant_invitation, tenant_member, user  # noqa: F401
 
 
 config = context.config

--- a/alembic/versions/202604260900_add_tokens.py
+++ b/alembic/versions/202604260900_add_tokens.py
@@ -1,0 +1,42 @@
+"""add password reset and email verification tokens
+
+Revision ID: 202604260900
+Revises: 202604260850
+Create Date: 2026-04-26 09:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202604260900"
+down_revision: str | None = "202604260850"
+branch_labels: str | Sequence[str] = ()
+depends_on: str | Sequence[str] = ()
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+    op.create_table(
+        "email_verification_tokens",
+        sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("email_verification_tokens")
+    op.drop_table("password_reset_tokens")

--- a/alembic/versions/202604260900_add_tokens.py
+++ b/alembic/versions/202604260900_add_tokens.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
         sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
     )
+    op.create_index(op.f("ix_password_reset_tokens_token_hash"), "password_reset_tokens", ["token_hash"], unique=True)
     op.create_table(
         "email_verification_tokens",
         sa.Column("id", sa.UUID(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
@@ -35,8 +36,11 @@ def upgrade() -> None:
         sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
     )
+    op.create_index(op.f("ix_email_verification_tokens_token_hash"), "email_verification_tokens", ["token_hash"], unique=True)
 
 
 def downgrade() -> None:
+    op.drop_index(op.f("ix_email_verification_tokens_token_hash"), table_name="email_verification_tokens")
     op.drop_table("email_verification_tokens")
+    op.drop_index(op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens")
     op.drop_table("password_reset_tokens")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,5 @@
+from app.models.email_verification_token import EmailVerificationToken
+from app.models.password_reset_token import PasswordResetToken
 from app.models.refresh_token import RefreshToken
 from app.models.role import Role
 from app.models.tenant import Tenant
@@ -5,4 +7,13 @@ from app.models.tenant_invitation import TenantInvitation
 from app.models.tenant_member import TenantMember
 from app.models.user import User
 
-__all__ = ["RefreshToken", "Role", "Tenant", "TenantInvitation", "TenantMember", "User"]
+__all__ = [
+    "EmailVerificationToken",
+    "PasswordResetToken",
+    "RefreshToken",
+    "Role",
+    "Tenant",
+    "TenantInvitation",
+    "TenantMember",
+    "User",
+]

--- a/app/models/email_verification_token.py
+++ b/app/models/email_verification_token.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class EmailVerificationToken(Base):
+    __tablename__ = "email_verification_tokens"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/email_verification_token.py
+++ b/app/models/email_verification_token.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
 
+if TYPE_CHECKING:
+    from app.models.user import User
+
 
 class EmailVerificationToken(Base):
-    __tablename__ = "email_verification_tokens"
+    __tablename__: str = "email_verification_tokens"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
     user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
@@ -17,3 +23,5 @@ class EmailVerificationToken(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="email_verification_tokens")

--- a/app/models/password_reset_token.py
+++ b/app/models/password_reset_token.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/models/password_reset_token.py
+++ b/app/models/password_reset_token.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
 
+if TYPE_CHECKING:
+    from app.models.user import User
+
 
 class PasswordResetToken(Base):
-    __tablename__ = "password_reset_tokens"
+    __tablename__: str = "password_reset_tokens"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
     user_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
@@ -17,3 +23,5 @@ class PasswordResetToken(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="password_reset_tokens")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -11,13 +11,15 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
 
 if TYPE_CHECKING:
+    from app.models.email_verification_token import EmailVerificationToken
+    from app.models.password_reset_token import PasswordResetToken
     from app.models.refresh_token import RefreshToken
     from app.models.tenant import Tenant
     from app.models.tenant_member import TenantMember
 
 
 class User(Base):
-    __tablename__ = "users"
+    __tablename__: str = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
@@ -32,5 +34,11 @@ class User(Base):
     )
 
     owned_tenants: Mapped[list["Tenant"]] = relationship(back_populates="owner")
+    email_verification_tokens: Mapped[list["EmailVerificationToken"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    password_reset_tokens: Mapped[list["PasswordResetToken"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
     refresh_tokens: Mapped[list["RefreshToken"]] = relationship(back_populates="user", cascade="all, delete-orphan")
     tenant_memberships: Mapped[list["TenantMember"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -7,6 +7,7 @@ from app.deps import get_db_session
 from app.middleware.auth import get_current_user
 from app.models.user import User
 from app.schemas.auth import AuthUserResponse, LoginRequest, LogoutRequest, MessageResponse, RefreshTokenRequest, RegisterRequest, TokenResponse
+from app.schemas.extended_auth import ForgotPasswordRequest, ResetPasswordRequest, VerifyEmailRequest
 from app.schemas.user import UserResponse
 from app.services.auth_service import AuthService
 from app.utils.errors import AppError
@@ -50,3 +51,21 @@ async def refresh(payload: RefreshTokenRequest, session: AsyncSession = Depends(
 @router.get("/me", response_model=UserResponse)
 async def me(current_user: User = Depends(get_current_user)):
     return {"data": current_user}
+
+
+@router.post("/verify-email", response_model=MessageResponse)
+async def verify_email(payload: VerifyEmailRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).verify_email(payload.token)
+    return {"data": {"message": "Email verified successfully."}}
+
+
+@router.post("/forgot-password", response_model=MessageResponse)
+async def forgot_password(payload: ForgotPasswordRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).forgot_password(payload.email)
+    return {"data": {"message": "If an account with that email exists, a reset link has been sent."}}
+
+
+@router.post("/reset-password", response_model=MessageResponse)
+async def reset_password(payload: ResetPasswordRequest, session: AsyncSession = Depends(get_db_session)):
+    await AuthService(session).reset_password(payload.token, payload.new_password)
+    return {"data": {"message": "Password reset successfully."}}

--- a/app/schemas/extended_auth.py
+++ b/app/schemas/extended_auth.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class VerifyEmailRequest(BaseModel):
@@ -11,4 +11,4 @@ class ForgotPasswordRequest(BaseModel):
 
 class ResetPasswordRequest(BaseModel):
     token: str
-    new_password: str
+    new_password: str = Field(min_length=8, max_length=128)

--- a/app/schemas/extended_auth.py
+++ b/app/schemas/extended_auth.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, EmailStr
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,5 +1,14 @@
 from app.services.auth_service import AuthService
+from app.services.email_verification_service import EmailVerificationService
+from app.services.password_reset_service import PasswordResetService
 from app.services.tenant_service import TenantSchemaService, TenantService
 from app.services.token_service import TokenService
 
-__all__ = ["AuthService", "TenantSchemaService", "TenantService", "TokenService"]
+__all__ = [
+    "AuthService",
+    "EmailVerificationService",
+    "PasswordResetService",
+    "TenantSchemaService",
+    "TenantService",
+    "TokenService",
+]

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -9,16 +9,19 @@ from app.models.refresh_token import RefreshToken
 from app.models.tenant_member import TenantMember
 from app.models.user import User
 from app.schemas.auth import LoginRequest, RegisterRequest, TokenData
+from app.services.email_verification_service import EmailVerificationService
+from app.services.password_reset_service import PasswordResetService
 from app.services.token_service import TokenService
-from app.utils.email import send_email
 from app.utils.errors import AppError
 from app.utils.security import hash_password, verify_password
 
 
 class AuthService:
     def __init__(self, session: AsyncSession):
-        self.session = session
-        self.token_service = TokenService()
+        self.session: AsyncSession = session
+        self.token_service: TokenService = TokenService()
+        self.email_verification_service: EmailVerificationService = EmailVerificationService(session, self.token_service)
+        self.password_reset_service: PasswordResetService = PasswordResetService(session, self.token_service)
 
     async def register(self, payload: RegisterRequest) -> User:
         existing = await self.session.scalar(select(User).where(User.email == payload.email.lower()))
@@ -32,15 +35,10 @@ class AuthService:
             last_name=payload.last_name.strip(),
         )
         self.session.add(user)
+        await self.session.flush()
+        await self.email_verification_service.issue_token(user)
         await self.session.commit()
         await self.session.refresh(user)
-
-        verification_token = self.token_service.create_verification_token(str(user.id), user.email)
-        await send_email(
-            recipient=user.email,
-            subject="Verify your account",
-            body=f"Welcome {user.first_name}, your verification token is: {verification_token}",
-        )
         return user
 
     async def login(self, payload: LoginRequest, tenant_id: UUID | None = None) -> TokenData:
@@ -107,8 +105,8 @@ class AuthService:
             raise AppError(403, "TENANT_ACCESS_DENIED", "User does not belong to this tenant.")
 
     async def verify_email(self, token: str) -> None:
-        payload = self.token_service.decode_token(token, expected_type="verify")
-        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        user_id = await self.email_verification_service.verify_token(token)
+        user = await self.session.scalar(select(User).where(User.id == user_id))
         if user is None:
             raise AppError(404, "USER_NOT_FOUND", "User not found.")
         if user.is_verified:
@@ -120,17 +118,10 @@ class AuthService:
         user = await self.session.scalar(select(User).where(User.email == email.lower()))
         if user is None:
             return
-        reset_token = self.token_service.create_verification_token(str(user.id), user.email)
-        await send_email(
-            recipient=user.email,
-            subject="Password Reset",
-            body=f"Your password reset token is: {reset_token}",
-        )
+        await self.password_reset_service.issue_token(user)
+        await self.session.commit()
 
     async def reset_password(self, token: str, new_password: str) -> None:
-        payload = self.token_service.decode_token(token, expected_type="verify")
-        user = await self.session.scalar(select(User).where(User.id == payload.subject))
-        if user is None:
-            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+        user = await self.password_reset_service.consume_token(token)
         user.password_hash = hash_password(new_password)
         await self.session.commit()

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -105,3 +105,32 @@ class AuthService:
         )
         if membership is None:
             raise AppError(403, "TENANT_ACCESS_DENIED", "User does not belong to this tenant.")
+
+    async def verify_email(self, token: str) -> None:
+        payload = self.token_service.decode_token(token, expected_type="verify")
+        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        if user is None:
+            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+        if user.is_verified:
+            raise AppError(400, "ALREADY_VERIFIED", "Email is already verified.")
+        user.is_verified = True
+        await self.session.commit()
+
+    async def forgot_password(self, email: str) -> None:
+        user = await self.session.scalar(select(User).where(User.email == email.lower()))
+        if user is None:
+            return
+        reset_token = self.token_service.create_verification_token(str(user.id), user.email)
+        await send_email(
+            recipient=user.email,
+            subject="Password Reset",
+            body=f"Your password reset token is: {reset_token}",
+        )
+
+    async def reset_password(self, token: str, new_password: str) -> None:
+        payload = self.token_service.decode_token(token, expected_type="verify")
+        user = await self.session.scalar(select(User).where(User.id == payload.subject))
+        if user is None:
+            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+        user.password_hash = hash_password(new_password)
+        await self.session.commit()

--- a/app/services/email_verification_service.py
+++ b/app/services/email_verification_service.py
@@ -1,0 +1,47 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.email_verification_token import EmailVerificationToken
+from app.models.user import User
+from app.services.token_service import TokenService
+from app.utils.email import send_email
+from app.utils.errors import AppError
+
+
+class EmailVerificationService:
+    def __init__(self, session: AsyncSession, token_service: TokenService):
+        self.session: AsyncSession = session
+        self.token_service: TokenService = token_service
+
+    async def issue_token(self, user: User) -> None:
+        raw_token = self.token_service.generate_opaque_token()
+        token_record = EmailVerificationToken(
+            user_id=user.id,
+            token_hash=self.token_service.hash_token(raw_token),
+            expires_at=self.token_service.email_verification_expires_at(),
+        )
+        self.session.add(token_record)
+        await self.session.flush()
+        await send_email(
+            recipient=user.email,
+            subject="Verify your account",
+            body=f"Welcome {user.first_name}, your verification token is: {raw_token}",
+        )
+
+    async def verify_token(self, token: str) -> UUID:
+        token_record = await self.session.scalar(
+            select(EmailVerificationToken).where(EmailVerificationToken.token_hash == self.token_service.hash_token(token))
+        )
+        if token_record is None:
+            raise AppError(401, "INVALID_TOKEN", "Token is invalid.")
+        if token_record.used_at is not None:
+            raise AppError(400, "TOKEN_ALREADY_USED", "Token has already been used.")
+        if token_record.expires_at <= datetime.now(UTC):
+            raise AppError(401, "TOKEN_EXPIRED", "Token has expired.")
+
+        token_record.used_at = datetime.now(UTC)
+        await self.session.flush()
+        return token_record.user_id

--- a/app/services/password_reset_service.py
+++ b/app/services/password_reset_service.py
@@ -1,0 +1,56 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.password_reset_token import PasswordResetToken
+from app.models.refresh_token import RefreshToken
+from app.models.user import User
+from app.services.token_service import TokenService
+from app.utils.email import send_email
+from app.utils.errors import AppError
+
+
+class PasswordResetService:
+    def __init__(self, session: AsyncSession, token_service: TokenService):
+        self.session: AsyncSession = session
+        self.token_service: TokenService = token_service
+
+    async def issue_token(self, user: User) -> None:
+        raw_token = self.token_service.generate_opaque_token()
+        token_record = PasswordResetToken(
+            user_id=user.id,
+            token_hash=self.token_service.hash_token(raw_token),
+            expires_at=self.token_service.password_reset_expires_at(),
+        )
+        self.session.add(token_record)
+        await self.session.flush()
+        await send_email(
+            recipient=user.email,
+            subject="Password Reset",
+            body=f"Your password reset token is: {raw_token}",
+        )
+
+    async def consume_token(self, token: str) -> User:
+        token_record = await self.session.scalar(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == self.token_service.hash_token(token))
+        )
+        if token_record is None:
+            raise AppError(401, "INVALID_TOKEN", "Token is invalid.")
+        if token_record.used_at is not None:
+            raise AppError(400, "TOKEN_ALREADY_USED", "Token has already been used.")
+        if token_record.expires_at <= datetime.now(UTC):
+            raise AppError(401, "TOKEN_EXPIRED", "Token has expired.")
+
+        user = await self.session.scalar(select(User).where(User.id == token_record.user_id))
+        if user is None:
+            raise AppError(404, "USER_NOT_FOUND", "User not found.")
+
+        token_record.used_at = datetime.now(UTC)
+        _ = await self.session.execute(
+            update(RefreshToken)
+            .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(UTC))
+        )
+        await self.session.flush()
+        return user

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,12 +1,14 @@
+import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
+from typing import cast
 from uuid import UUID
 
 import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import get_settings
+from app.config import Settings, get_settings
 from app.models.refresh_token import RefreshToken
 from app.schemas.auth import TokenData
 from app.utils.errors import AppError
@@ -21,14 +23,16 @@ class TokenPayload:
 
 class TokenService:
     def __init__(self):
-        self.settings = get_settings()
+        self.settings: Settings = get_settings()
 
     def create_access_token(self, user_id: str, tenant_id: UUID | None = None) -> tuple[str, datetime]:
         expires_at = datetime.now(UTC) + timedelta(minutes=self.settings.jwt_access_expire_minutes)
         payload = {"sub": user_id, "type": "access", "exp": expires_at}
         if tenant_id is not None:
             payload["tenant_id"] = str(tenant_id)
-        token = jwt.encode(payload, self.settings.jwt_secret, algorithm=self.settings.jwt_algorithm)
+        token: str = jwt.encode(  # pyright: ignore[reportUnknownMemberType]
+            payload, self.settings.jwt_secret, algorithm=self.settings.jwt_algorithm
+        )
         return token, expires_at
 
     def create_refresh_token(self, user_id: str, tenant_id: UUID | None = None) -> tuple[str, datetime]:
@@ -36,16 +40,19 @@ class TokenService:
         payload = {"sub": user_id, "type": "refresh", "exp": expires_at}
         if tenant_id is not None:
             payload["tenant_id"] = str(tenant_id)
-        token = jwt.encode(payload, self.settings.jwt_secret, algorithm=self.settings.jwt_algorithm)
+        token: str = jwt.encode(  # pyright: ignore[reportUnknownMemberType]
+            payload, self.settings.jwt_secret, algorithm=self.settings.jwt_algorithm
+        )
         return token, expires_at
 
-    def create_verification_token(self, user_id: str, email: str) -> str:
-        expires_at = datetime.now(UTC) + timedelta(hours=24)
-        return jwt.encode(
-            {"sub": user_id, "email": email, "type": "verify", "exp": expires_at},
-            self.settings.jwt_secret,
-            algorithm=self.settings.jwt_algorithm,
-        )
+    def generate_opaque_token(self) -> str:
+        return secrets.token_urlsafe(32)
+
+    def email_verification_expires_at(self) -> datetime:
+        return datetime.now(UTC) + timedelta(hours=24)
+
+    def password_reset_expires_at(self) -> datetime:
+        return datetime.now(UTC) + timedelta(hours=1)
 
     async def issue_token_pair(self, session: AsyncSession, user_id: UUID, tenant_id: UUID | None = None) -> TokenData:
         access_token, _ = self.create_access_token(str(user_id), tenant_id=tenant_id)
@@ -68,21 +75,23 @@ class TokenService:
 
     def decode_token(self, token: str, expected_type: str | None = None) -> TokenPayload:
         try:
-            payload = jwt.decode(token, self.settings.jwt_secret, algorithms=[self.settings.jwt_algorithm])
+            payload: dict[str, object] = jwt.decode(  # pyright: ignore[reportUnknownMemberType]
+                token, self.settings.jwt_secret, algorithms=[self.settings.jwt_algorithm]
+            )
         except jwt.ExpiredSignatureError as exc:
             raise AppError(401, "TOKEN_EXPIRED", "Token has expired.") from exc
         except jwt.InvalidTokenError as exc:
             raise AppError(401, "INVALID_TOKEN", "Token is invalid.") from exc
 
-        token_type = payload.get("type", "access")
+        token_type = cast(str, payload.get("type", "access"))
         if expected_type and token_type != expected_type:
             raise AppError(401, "INVALID_TOKEN_TYPE", "Token type is invalid.")
 
-        subject = payload.get("sub")
+        subject = cast(str | None, payload.get("sub"))
         if subject is None:
             raise AppError(401, "INVALID_TOKEN", "Token subject is missing.")
 
-        tenant_id = payload.get("tenant_id")
+        tenant_id = cast(str | None, payload.get("tenant_id"))
 
         return TokenPayload(
             subject=UUID(subject),


### PR DESCRIPTION
## Summary
- add Alembic + SQLAlchemy support for persisted email verification and password reset tokens in the multi-tenant auth template
- move verification and reset flows onto opaque hashed tokens with single-use enforcement and refresh-token revocation on password reset
- keep the existing auth API shape while tightening reset password validation and preserving tenant-aware login flows